### PR TITLE
Fix auto-refresh when changing profile

### DIFF
--- a/src/app/redux/threeCommas/Actions.ts
+++ b/src/app/redux/threeCommas/Actions.ts
@@ -318,13 +318,13 @@ const refreshFunction = (method: string, offset?: number) => {
             store.dispatch(setAutoRefresh(false))
             break
         case 'run':
-            const profileData = preSyncCheck(store.getState().config.currentProfile)
-            if (!profileData) {
-                refreshFunction('stop')
-                return
-            }
-
             setTimeout(() => {
+                const profileData = preSyncCheck(store.getState().config.currentProfile)
+                if (!profileData) {
+                    refreshFunction('stop')
+                    return
+                }
+
                 if(!store.getState().threeCommas.autoRefresh) return
                 updateAllData(offset, profileData, 'autoSync', undefined)
                     .then(() => {


### PR DESCRIPTION
Auto refresh would use the profile which was loaded when it started, this change pull the current profile at execution time to make sure we refresh the current profile